### PR TITLE
Refactors acceptance tests to avoid flakes

### DIFF
--- a/src/spec/metrics/acceptance_suite_test.go
+++ b/src/spec/metrics/acceptance_suite_test.go
@@ -16,9 +16,12 @@ func TestAcceptance(t *testing.T) {
 	RunSpecs(t, "MySql monitoring release Acceptance Suite")
 }
 
-var TestSetup *workflowhelpers.ReproducibleTestSuiteSetup
-var Config *config.Config
-var SourceID string
+var (
+	TestSetup  *workflowhelpers.ReproducibleTestSuiteSetup
+	Config     *config.Config
+	SourceID   string
+	deployment string
+)
 
 var _ = BeforeSuite(func() {
 	var missingEnvs []string
@@ -44,6 +47,7 @@ var _ = BeforeSuite(func() {
 	TestSetup = workflowhelpers.NewTestSuiteSetup(Config)
 	TestSetup.Setup()
 
+	deployment = os.Getenv("BOSH_DEPLOYMENT")
 	SourceID = os.Getenv("METRICS_SOURCE_ID")
 })
 

--- a/src/spec/utilities/bosh/bosh.go
+++ b/src/spec/utilities/bosh/bosh.go
@@ -1,0 +1,91 @@
+package bosh
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/cloudfoundry/mysql-monitoring-release/spec/utilities/cmd"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/gomega"
+)
+
+type MatchInstanceFunc func(instance Instance) bool
+
+type Instance struct {
+	IP       string `json:"ips"`
+	Instance string `json:"instance"`
+	Index    string `json:"index"`
+	VMCid    string `json:"vm_cid"`
+}
+
+func (i *Instance) Id() string {
+	components := strings.SplitN(i.Instance, "/", 2)
+	Expect(components).To(HaveLen(2))
+	return components[1]
+}
+
+// MatchByIndexedName matches by comparing the provided name to INSTANCE-GROUP/INDEX
+func MatchByIndexedName(name string) MatchInstanceFunc {
+	return func(i Instance) bool {
+		components := strings.SplitN(i.Instance, "/", 2)
+		instanceGroup := components[0]
+		return instanceGroup+"/"+i.Index == name
+	}
+}
+
+func Instances(deploymentName string, matchInstanceFunc MatchInstanceFunc) ([]Instance, error) {
+	var output bytes.Buffer
+
+	fmt.Printf("deploymentName: %s\n", deploymentName)
+	if err := cmd.RunWithoutOutput(&output,
+		"bosh",
+		"--non-interactive",
+		"--tty",
+		"--deployment="+deploymentName,
+		"instances",
+		"--details",
+		"--json",
+	); err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Tables []struct {
+			Rows []Instance
+		}
+	}
+
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		return nil, fmt.Errorf("failed to decode bosh instances output: %v", err)
+	}
+
+	var instances []Instance
+
+	for _, row := range result.Tables[0].Rows {
+		if matchInstanceFunc(row) {
+			instances = append(instances, row)
+		}
+	}
+
+	sort.SliceStable(instances, func(i, j int) bool {
+		return instances[i].Index < instances[j].Index
+	})
+
+	return instances, nil
+}
+
+func RemoteCommand(deploymentName, instanceSpec, cmdString string) (string, error) {
+	var output bytes.Buffer
+	err := cmd.RunWithoutOutput(&output,
+		"bosh",
+		"--deployment="+deploymentName,
+		"ssh",
+		instanceSpec,
+		"--column=Stdout",
+		"--results",
+		"--command="+cmdString,
+	)
+	return strings.TrimSpace(output.String()), err
+}

--- a/src/spec/utilities/bosh/bosh.go
+++ b/src/spec/utilities/bosh/bosh.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/cloudfoundry/mysql-monitoring-release/spec/utilities/cmd"
 	"sort"
 	"strings"
+
+	"github.com/cloudfoundry/mysql-monitoring-release/spec/utilities/cmd"
 
 	. "github.com/onsi/gomega"
 )

--- a/src/spec/utilities/cmd/cmd.go
+++ b/src/spec/utilities/cmd/cmd.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+type MutatorFunc func(*exec.Cmd)
+
+func RunWithoutOutput(w io.Writer, name string, args ...string) error {
+	return RunCustom(func(cmd *exec.Cmd) { cmd.Stdout = w }, name, args...)
+}
+
+func RunCustom(mutator MutatorFunc, name string, args ...string) error {
+	defer ginkgo.GinkgoWriter.Println()
+	cmd := exec.Command(name, args...)
+	cmd.Stderr = ginkgo.GinkgoWriter
+	cmd.Stdout = ginkgo.GinkgoWriter
+
+	if mutator != nil {
+		mutator(cmd)
+	}
+
+	ginkgo.GinkgoWriter.Println("$", strings.Join(cmd.Args, " "))
+	return cmd.Run()
+}


### PR DESCRIPTION
While testing in the new shepherd v1 environment, the ephemeral disk test began to fail - not sure how it worked before, but it was using `cf tail` to get the metric value. But since it was running an open `cf tail` without any filtering, and it always took the first value it found, there was no guarantee that the first metric it found was emitted from mysql/0

Updates the test to find the VM's ID via bosh, and then uses that ID to run `cf query` instead - this allows us to select for the correct ID to make sure we are always getting the metrics from mysql/0

This change also consolidates what was two different "By" blocks. Previously we would get the disk usage after allocating data in one block, and then assert on the delta in another block. That felt overly complex, and we can instead combine this via the eventually block to directly assert the value is within our expected range

Minor refactoring to use a more standard pattern for running bosh commands

[TNZ-37039](https://vmw-jira.broadcom.net/browse/TNZ-37039)

Authored-by: Ryan Wittrup <ryan.wittrup@broadcom.com>