### PR TITLE
Fix go1.25 vet issue

### DIFF
--- a/src/mysql-diag/mysql-diag-agent/config/config_test.go
+++ b/src/mysql-diag/mysql-diag-agent/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"code.cloudfoundry.org/tlsconfig/certtest"
 	. "github.com/onsi/ginkgo/v2"
@@ -213,7 +214,7 @@ var _ = Describe("config", func() {
 					errCh <- err
 				}()
 
-				address := fmt.Sprintf("%s:%d", rootConfig.BindAddress, rootConfig.Port)
+				address := net.JoinHostPort(rootConfig.BindAddress, strconv.FormatUint(uint64(rootConfig.Port), 10))
 				conn, err := net.Dial("tcp", address)
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Addresses a unit test failure in the mysql-diag module when run with the go 1.25 toolchain.