### PR TITLE
Add stricter TLS validation to mysql-diag

### DIFF
--- a/jobs/mysql-diag/spec
+++ b/jobs/mysql-diag/spec
@@ -22,3 +22,13 @@ properties:
     description: MySQL username to connect to cluster nodes
   db_password:
     description: MySQL password to connect to cluster nodes
+  db_tls.ca:
+    description: |
+      PEM-encoded CA certificate used to verify the MySQL server's TLS certificate.
+      When set, mysql-diag verifies the server's certificate chain.
+      When omitted, TLS is still used but the server certificate is not verified.
+  db_tls.server_name:
+    description: |
+      Expected server name (SNI) for the MySQL server's TLS certificate.
+      Required when db_tls.ca is set; enables full CA chain and hostname verification.
+      Must not be set without db_tls.ca.

--- a/jobs/mysql-diag/templates/mysql-diag-config.yml.erb
+++ b/jobs/mysql-diag/templates/mysql-diag-config.yml.erb
@@ -47,6 +47,24 @@ if_p('db_username', 'db_password') do |db_username, db_password|
   config[:mysql][:password] = db_password
 end
 
+db_tls_ca          = p('db_tls.ca', nil)
+db_tls_server_name = p('db_tls.server_name', nil)
+
+db_tls_ca_present          = !db_tls_ca.nil?          && !db_tls_ca.empty?
+db_tls_server_name_present = !db_tls_server_name.nil? && !db_tls_server_name.empty?
+
+if db_tls_ca_present && !db_tls_server_name_present
+  raise 'db_tls.server_name is required when db_tls.ca is configured'
+end
+if db_tls_server_name_present && !db_tls_ca_present
+  raise 'db_tls.ca is required when db_tls.server_name is configured'
+end
+
+if db_tls_ca_present
+  config[:mysql][:ca]          = db_tls_ca
+  config[:mysql][:server_name] = db_tls_server_name
+end
+
 if config[:mysql][:username].nil? or config[:mysql][:password].nil?
  raise 'No database credentials were configured. db_username and db_password properties must be specified for the mysql-diag job.'
 end

--- a/operations/mysql-diag-db-tls.yml
+++ b/operations/mysql-diag-db-tls.yml
@@ -1,0 +1,15 @@
+# ensure bosh/credhub regenerates the mysql server crt with a new SAN
+- type: replace
+  path: /variables/name=mysql_server_certificate/update_mode?
+  value: converge
+
+# set a well-known SAN for test verification purposes
+- type: replace
+  path: /variables/name=mysql_server_certificate/options/alternative_names?
+  value: [mysql-diag-test]
+
+- type: replace
+  path: /instance_groups/name=mysql-monitor/jobs/name=mysql-diag/properties/db_tls?
+  value:
+    ca: ((mysql_server_certificate.ca))
+    server_name: mysql-diag-test

--- a/spec/mysql-diag-config_spec.rb
+++ b/spec/mysql-diag-config_spec.rb
@@ -90,4 +90,58 @@ describe 'jobs/mysql-diag/config/mysql-diag-config.yml' do
     end
   end
 
+  context 'db_tls properties' do
+    context 'when neither db_tls.ca nor db_tls.server_name are set' do
+      it 'omits ca and server_name from the mysql config' do
+        expect(parsed_config['mysql']).not_to have_key('ca')
+        expect(parsed_config['mysql']).not_to have_key('server_name')
+      end
+    end
+
+    context 'when both db_tls.ca and db_tls.server_name are set' do
+      let(:spec) do
+        {
+          'db_username'  => 'mysql-diag-user',
+          'db_password'  => 'mysql-diag-password',
+          'db_tls' => { 'ca' => 'pem-encoded-ca-cert', 'server_name' => 'mysql.internal' },
+        }
+      end
+
+      it 'includes ca and server_name in the mysql config' do
+        expect(parsed_config).to include('mysql' => hash_including(
+          'ca'          => 'pem-encoded-ca-cert',
+          'server_name' => 'mysql.internal',
+        ))
+      end
+    end
+
+    context 'when db_tls.ca is set without db_tls.server_name' do
+      let(:spec) do
+        {
+          'db_username' => 'mysql-diag-user',
+          'db_password' => 'mysql-diag-password',
+          'db_tls' => { 'ca' => 'pem-encoded-ca-cert' },
+        }
+      end
+
+      it 'errors on rendering' do
+        expect { rendered_template }.to raise_error('db_tls.server_name is required when db_tls.ca is configured')
+      end
+    end
+
+    context 'when db_tls.server_name is set without db_tls.ca' do
+      let(:spec) do
+        {
+          'db_username' => 'mysql-diag-user',
+          'db_password' => 'mysql-diag-password',
+          'db_tls' => { 'server_name' => 'mysql.internal' },
+        }
+      end
+
+      it 'errors on rendering' do
+        expect { rendered_template }.to raise_error('db_tls.ca is required when db_tls.server_name is configured')
+      end
+    end
+  end
+
 end

--- a/src/mysql-diag/bin/test-unit
+++ b/src/mysql-diag/bin/test-unit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+module_dir="$(cd "${script_dir}/.." && pwd)"
+
+cd "${module_dir}"
+
+go run github.com/onsi/ginkgo/v2/ginkgo \
+      -r \
+      --compilers=2 \
+      --procs=4 \
+      -race \
+      --fail-on-pending \
+      --randomize-all \
+      --randomize-suites \
+      --skip-package=integration \
+      "$@"

--- a/src/mysql-diag/config/config.go
+++ b/src/mysql-diag/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os"
 
 	"code.cloudfoundry.org/tlsconfig"
+	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"gopkg.in/yaml.v2"
 
@@ -28,12 +30,14 @@ type GaleraAgentConfig struct {
 }
 
 type MysqlConfig struct {
-	Username  string           `yaml:"username"`
-	Password  string           `yaml:"password"`
-	Port      uint             `yaml:"port"`
-	Agent     *AgentConfig     `yaml:"agent"`
-	Threshold *ThresholdConfig `yaml:"threshold"`
-	Nodes     []MysqlNode      `yaml:"nodes"`
+	Username   string           `yaml:"username"`
+	Password   string           `yaml:"password"`
+	Port       uint             `yaml:"port"`
+	Agent      *AgentConfig     `yaml:"agent"`
+	Threshold  *ThresholdConfig `yaml:"threshold"`
+	Nodes      []MysqlNode      `yaml:"nodes"`
+	CA         string           `yaml:"ca"`
+	ServerName string           `yaml:"server_name"`
 }
 
 type AgentConfig struct {
@@ -61,10 +65,14 @@ type TLS struct {
 }
 
 func (mysqlConfig *MysqlConfig) ConnectionString(node MysqlNode) string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/?timeout=10s&readTimeout=10s&tls=preferred", mysqlConfig.Username, mysqlConfig.Password, node.Host, mysqlConfig.Port)
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/?timeout=10s&readTimeout=10s&tls=mysql-diag", mysqlConfig.Username, mysqlConfig.Password, node.Host, mysqlConfig.Port)
 }
 
 func (mysqlConfig *MysqlConfig) Connection(node MysqlNode) *sql.DB {
+	if err := initializeMySQLTLS(*mysqlConfig); err != nil {
+		msg.PrintfError("Database TLS configuration problem: %v", err)
+		os.Exit(1)
+	}
 	conn, err := sql.Open("mysql", mysqlConfig.ConnectionString(node))
 	if err != nil {
 		msg.PrintfError("Database configuration problem: %v", err)
@@ -116,5 +124,41 @@ func LoadFromFile(filepath string) (*Config, error) {
 		return nil, err
 	}
 
+	if err = initializeMySQLTLS(c.Mysql); err != nil {
+		return nil, err
+	}
+
 	return &c, nil
+}
+
+func initializeMySQLTLS(mysqlCfg MysqlConfig) error {
+	var tlsCfg *tls.Config
+
+	switch {
+	case mysqlCfg.CA != "" && mysqlCfg.ServerName != "":
+		pool, err := parseCACertPool(mysqlCfg.CA)
+		if err != nil {
+			return err
+		}
+		tlsCfg = &tls.Config{RootCAs: pool, ServerName: mysqlCfg.ServerName}
+
+	case mysqlCfg.CA != "" || mysqlCfg.ServerName != "":
+		return fmt.Errorf("db_tls.ca and db_tls.server_name must both be set or both be omitted")
+
+	default:
+		tlsCfg = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	if err := mysql.RegisterTLSConfig("mysql-diag", tlsCfg); err != nil {
+		return fmt.Errorf("failed to register mysql TLS config: %v", err)
+	}
+	return nil
+}
+
+func parseCACertPool(ca string) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	if ok := pool.AppendCertsFromPEM([]byte(ca)); !ok {
+		return nil, fmt.Errorf("mysql CA: not valid PEM-encoded certificate data")
+	}
+	return pool, nil
 }

--- a/src/mysql-diag/config/config_test.go
+++ b/src/mysql-diag/config/config_test.go
@@ -193,17 +193,45 @@ var _ = Describe("config", func() {
 		})
 	})
 
-	Describe("ConnectionString", func() {
-		It("builds a mysql connection string", func() {
-			Expect(mysqlConfig.ConnectionString(node)).To(Equal("someuser:somepassword@tcp(nowhere.example.com:3306)/?timeout=10s&readTimeout=10s&tls=preferred"))
+	Context("db_tls validation", func() {
+		writeMinimalConfig := func(ca, serverName string) {
+			formatted := fmt.Sprintf(`{"mysql":{"username":"u","password":"p","port":3306,"ca":%q,"server_name":%q,"nodes":[]}}`, ca, serverName)
+			err := os.WriteFile(configFilepath, []byte(formatted), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		It("returns an error when ca is set but server_name is omitted", func() {
+			writeMinimalConfig("some-ca-pem", "")
+			_, err := config.LoadFromFile(configFilepath)
+			Expect(err).To(MatchError(ContainSubstring("both be set or both be omitted")))
+		})
+
+		It("returns an error when server_name is set but ca is omitted", func() {
+			writeMinimalConfig("", "mysql.internal")
+			_, err := config.LoadFromFile(configFilepath)
+			Expect(err).To(MatchError(ContainSubstring("both be set or both be omitted")))
+		})
+
+		It("returns an error when ca is not valid PEM", func() {
+			writeMinimalConfig("not-valid-pem-content", "mysql.internal")
+			_, err := config.LoadFromFile(configFilepath)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
-	It("provides a database connection object", func() {
-		conn := mysqlConfig.Connection(node)
+	Describe("ConnectionString", func() {
+		It("builds a mysql connection string", func() {
+			Expect(mysqlConfig.ConnectionString(node)).To(Equal("someuser:somepassword@tcp(nowhere.example.com:3306)/?timeout=10s&readTimeout=10s&tls=mysql-diag"))
+		})
+	})
 
-		// It's not really connected to the database, it's lazy, so there's not much to assert
-		Expect(conn).ToNot(BeNil())
+	Describe("Connection", func() {
+		It("provides a database connection object", func() {
+			conn := mysqlConfig.Connection(node)
+
+			// It's not really connected to the database, it's lazy, so there's not much to assert
+			Expect(conn).ToNot(BeNil())
+		})
 	})
 
 	It("provides a list of hosts with logs", func() {

--- a/src/mysql-diag/data/aggregator.go
+++ b/src/mysql-diag/data/aggregator.go
@@ -13,7 +13,8 @@ type Data struct {
 	NodeDiskInfo    []disk.NodeDiskInfo
 	DiskSpaceIssues []disk.DiskSpaceIssue
 
-	NeedsBootstrap bool
+	NeedsBootstrap   bool
+	TLSMisconfigured bool
 }
 
 type aggregator struct {
@@ -38,6 +39,7 @@ func (a aggregator) Aggregate() Data {
 	}
 	database.GetNodeClusterStatuses(a.mySQL, nodeClusterStatuses)
 	needsBootstrap := database.CheckClusterBootstrapStatus(nodeClusterStatuses)
+	tlsMisconfigured := database.HasTLSErrors(nodeClusterStatuses)
 	mysqlAgentClient.GetSequenceNumbers(a.galeraAgent, nodeClusterStatuses)
 	nodeDiskInfos := disk.GetNodeDiskInfos(a.mySQL)
 	diskSpaceIssues := disk.CheckDiskStatus(nodeDiskInfos, a.mySQL.Threshold)
@@ -52,5 +54,6 @@ func (a aggregator) Aggregate() Data {
 		NodeDiskInfo:        nodeDiskInfos,
 		DiskSpaceIssues:     diskSpaceIssues,
 		NeedsBootstrap:      needsBootstrap,
+		TLSMisconfigured:    tlsMisconfigured,
 	}
 }

--- a/src/mysql-diag/database/bootstrappable.go
+++ b/src/mysql-diag/database/bootstrappable.go
@@ -1,5 +1,14 @@
 package database
 
+func HasTLSErrors(rows map[string]*NodeClusterStatus) bool {
+	for _, row := range rows {
+		if IsTLSError(row.Err) {
+			return true
+		}
+	}
+	return false
+}
+
 func DoWeNeedBootstrap(gs []*GaleraStatus) bool {
 	if len(gs) == 0 {
 		return false

--- a/src/mysql-diag/database/bootstrappable_test.go
+++ b/src/mysql-diag/database/bootstrappable_test.go
@@ -1,11 +1,70 @@
 package database_test
 
 import (
+	"crypto/tls"
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	. "github.com/cloudfoundry/mysql-diag/database"
 )
+
+var _ = Describe("IsTLSError", func() {
+	It("returns true for a tls.CertificateVerificationError", func() {
+		err := &tls.CertificateVerificationError{Err: fmt.Errorf("x509: certificate is valid for localhost, not mysql-diag")}
+		Expect(IsTLSError(err)).To(BeTrue())
+	})
+
+	It("returns true when the TLS error is wrapped", func() {
+		inner := &tls.CertificateVerificationError{Err: fmt.Errorf("hostname mismatch")}
+		wrapped := fmt.Errorf("dial failed: %w", inner)
+		Expect(IsTLSError(wrapped)).To(BeTrue())
+	})
+
+	It("returns false for a plain connection error", func() {
+		Expect(IsTLSError(fmt.Errorf("connection refused"))).To(BeFalse())
+	})
+
+	It("returns false for nil", func() {
+		Expect(IsTLSError(nil)).To(BeFalse())
+	})
+})
+
+var _ = Describe("HasTLSErrors", func() {
+	tlsErr := &tls.CertificateVerificationError{Err: fmt.Errorf("x509: certificate is valid for localhost, not mysql-diag")}
+
+	It("returns true when any node has a TLS error", func() {
+		rows := map[string]*NodeClusterStatus{
+			"10.0.0.1": {Err: tlsErr},
+			"10.0.0.2": {Err: tlsErr},
+			"10.0.0.3": {Err: tlsErr},
+		}
+		Expect(HasTLSErrors(rows)).To(BeTrue())
+	})
+
+	It("returns true when only some nodes have TLS errors", func() {
+		rows := map[string]*NodeClusterStatus{
+			"10.0.0.1": {Err: tlsErr},
+			"10.0.0.2": {Status: &GaleraStatus{LocalState: "Synced"}},
+		}
+		Expect(HasTLSErrors(rows)).To(BeTrue())
+	})
+
+	It("returns false when errors are non-TLS", func() {
+		rows := map[string]*NodeClusterStatus{
+			"10.0.0.1": {Err: fmt.Errorf("connection refused")},
+		}
+		Expect(HasTLSErrors(rows)).To(BeFalse())
+	})
+
+	It("returns false when there are no errors", func() {
+		rows := map[string]*NodeClusterStatus{
+			"10.0.0.1": {Status: &GaleraStatus{LocalState: "Synced"}},
+		}
+		Expect(HasTLSErrors(rows)).To(BeFalse())
+	})
+})
 
 var _ = Describe("bootstrappable", func() {
 

--- a/src/mysql-diag/database/databaseclient.go
+++ b/src/mysql-diag/database/databaseclient.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"crypto/tls"
 	"database/sql"
 	"errors"
 	"strconv"
@@ -21,6 +22,12 @@ type GaleraStatus struct {
 type NodeClusterStatus struct {
 	Node   config.MysqlNode
 	Status *GaleraStatus
+	Err    error
+}
+
+func IsTLSError(err error) bool {
+	var certErr *tls.CertificateVerificationError
+	return errors.As(err, &certErr)
 }
 
 type DatabaseClient struct {
@@ -125,7 +132,7 @@ func GetNodeClusterStatuses(mysqlConfig config.MysqlConfig, nodeClusterStatus ma
 			if galeraStatus == nil {
 				galeraStatus = s
 			}
-			channel <- NodeClusterStatus{Node: n, Status: galeraStatus}
+			channel <- NodeClusterStatus{Node: n, Status: galeraStatus, Err: err}
 		}()
 	}
 

--- a/src/mysql-diag/integration/mysql_diag_config_test.go
+++ b/src/mysql-diag/integration/mysql_diag_config_test.go
@@ -1,0 +1,232 @@
+package integration_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"database/sql"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+
+	"github.com/cloudfoundry/mysql-diag/config"
+	"github.com/cloudfoundry/mysql-diag/database"
+	"github.com/cloudfoundry/mysql-diag/internal/testing/docker"
+)
+
+// tlsTestServerName is the DNS SAN on the server cert. It differs from the TCP address
+// (127.0.0.1) so that verify_identity must use the configured ServerName — not the IP —
+// to pass x509 hostname verification.
+const tlsTestServerName = "mysql-tls-test.internal"
+
+var _ = Describe("mysql-diag TLS config", Ordered, Label("integration"), func() {
+	var (
+		containerID string
+		mysqlPort   uint64
+		caPEM       []byte
+	)
+
+	BeforeAll(func() {
+		var certPEM, keyPEM []byte
+		var err error
+		caPEM, certPEM, keyPEM, err = generateTLSCerts(tlsTestServerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		certDir, err := os.MkdirTemp("", "mysql-tls-certs-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(certDir) })
+
+		for name, data := range map[string][]byte{
+			"ca.pem":          caPEM,
+			"server-cert.pem": certPEM,
+			"server-key.pem":  keyPEM,
+		} {
+			Expect(os.WriteFile(filepath.Join(certDir, name), data, 0644)).To(Succeed())
+		}
+
+		containerID, err = docker.RunContainer(docker.ContainerSpec{
+			Image:          "percona/percona-server:8.0",
+			Ports:          []string{"3306/tcp"},
+			HealthCmd:      "mysqladmin ping --host=127.0.0.1",
+			HealthInterval: "3s",
+			Env:            []string{"MYSQL_ALLOW_EMPTY_PASSWORD=1"},
+			Volumes:        []string{certDir + ":/etc/mysql/ssl"},
+			Args: []string{
+				"--ssl-ca=/etc/mysql/ssl/ca.pem",
+				"--ssl-cert=/etc/mysql/ssl/server-cert.pem",
+				"--ssl-key=/etc/mysql/ssl/server-key.pem",
+				"--require-secure-transport=ON",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { Expect(docker.RemoveContainer(containerID)).To(Succeed()) })
+
+		Expect(docker.WaitHealthy(containerID, time.Minute)).To(Succeed())
+
+		containerPort, err := docker.ContainerPort(containerID, "3306/tcp")
+		Expect(err).NotTo(HaveOccurred())
+
+		mysqlPort, err = strconv.ParseUint(containerPort, 10, 16)
+		Expect(err).NotTo(HaveOccurred())
+
+		caPool := x509.NewCertPool()
+		caPool.AppendCertsFromPEM(caPEM)
+		Expect(mysql.RegisterTLSConfig("healthcheck", &tls.Config{
+			RootCAs:    caPool,
+			ServerName: tlsTestServerName,
+		})).To(Succeed())
+		healthDB, err := sql.Open("mysql", fmt.Sprintf("root@tcp(127.0.0.1:%d)/?tls=healthcheck", mysqlPort))
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(healthDB.Close)
+
+		Eventually(healthDB.Ping, "3m", "2s").Should(Succeed(),
+			"timed out waiting for MySQL to accept connections")
+	})
+
+	// writeConfig marshals a minimal mysql-diag config file pointing at the running container.
+	writeConfig := func(ca, serverName string) string {
+		cfg := config.MysqlConfig{
+			Username:   "root",
+			Password:   "",
+			Port:       uint(mysqlPort),
+			CA:         ca,
+			ServerName: serverName,
+			Nodes:      []config.MysqlNode{{Host: "127.0.0.1", Name: "mysql", UUID: "test"}},
+		}
+
+		data, err := yaml.Marshal(map[string]config.MysqlConfig{"mysql": cfg})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		dir, err := os.MkdirTemp("", "mysql-diag-cfg-*")
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(dir) })
+
+		path := filepath.Join(dir, "config.yml")
+		ExpectWithOffset(1, os.WriteFile(path, data, 0644)).To(Succeed())
+		return path
+	}
+
+	It("connects in required mode — TLS encrypted, no certificate verification", func() {
+		cfg, err := config.LoadFromFile(writeConfig("", ""))
+		Expect(err).NotTo(HaveOccurred())
+
+		db := cfg.Mysql.Connection(cfg.Mysql.Nodes[0])
+		DeferCleanup(db.Close)
+		Expect(db.Ping()).To(Succeed())
+	})
+
+	It("connects in verify_identity mode — verifies CA chain AND hostname", func() {
+		cfg, err := config.LoadFromFile(writeConfig(string(caPEM), tlsTestServerName))
+		Expect(err).NotTo(HaveOccurred())
+
+		db := cfg.Mysql.Connection(cfg.Mysql.Nodes[0])
+		DeferCleanup(db.Close)
+		Expect(db.Ping()).To(Succeed())
+	})
+
+	It("fails with a certificate error when server_name does not match the certificate's DNS name", func() {
+		cfg, err := config.LoadFromFile(writeConfig(string(caPEM), "wrong-hostname.internal"))
+		Expect(err).NotTo(HaveOccurred())
+
+		db := cfg.Mysql.Connection(cfg.Mysql.Nodes[0])
+		DeferCleanup(db.Close)
+
+		err = db.Ping()
+		Expect(err).To(HaveOccurred())
+		Expect(database.IsTLSError(err)).To(BeTrue(), "expected a certificate verification error, got: %v", err)
+	})
+
+	It("fails with a certificate error when ca does not match the server's certificate chain", func() {
+		foreignCAPEM, _, _, err := generateTLSCerts(tlsTestServerName)
+		Expect(err).NotTo(HaveOccurred())
+
+		cfg, err := config.LoadFromFile(writeConfig(string(foreignCAPEM), tlsTestServerName))
+		Expect(err).NotTo(HaveOccurred())
+
+		db := cfg.Mysql.Connection(cfg.Mysql.Nodes[0])
+		DeferCleanup(db.Close)
+
+		err = db.Ping()
+		Expect(err).To(HaveOccurred())
+		Expect(database.IsTLSError(err)).To(BeTrue(), "expected a certificate verification error, got: %v", err)
+	})
+})
+
+// generateTLSCerts produces a self-signed CA and a server certificate bearing dnsName as
+// the only DNS SAN. The server cert has no IP SANs, so TLS hostname verification against
+// an IP address (127.0.0.1) will only succeed when the client explicitly sets ServerName
+// to dnsName.
+func generateTLSCerts(dnsName string) (caPEM, certPEM, keyPEM []byte, err error) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		return
+	}
+
+	var buf bytes.Buffer
+	if err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: caDER}); err != nil {
+		return
+	}
+	caPEM = bytes.Clone(buf.Bytes())
+	buf.Reset()
+
+	serverKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return
+	}
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: dnsName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		DNSNames:     []string{dnsName},
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return
+	}
+	if err = pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: serverDER}); err != nil {
+		return
+	}
+	certPEM = bytes.Clone(buf.Bytes())
+	buf.Reset()
+
+	keyDER, err := x509.MarshalECPrivateKey(serverKey)
+	if err != nil {
+		return
+	}
+	err = pem.Encode(&buf, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	keyPEM = buf.Bytes()
+	return
+}

--- a/src/mysql-diag/integration/suite_test.go
+++ b/src/mysql-diag/integration/suite_test.go
@@ -1,0 +1,13 @@
+package integration_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MySQL Diag Integration Suite")
+}

--- a/src/mysql-diag/internal/testing/docker/docker.go
+++ b/src/mysql-diag/internal/testing/docker/docker.go
@@ -1,0 +1,127 @@
+package docker
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+type ContainerSpec struct {
+	Image          string
+	Ports          []string
+	HealthCmd      string
+	HealthInterval string
+	Env            []string
+	Volumes        []string
+	Args           []string
+}
+
+func Command(args ...string) (string, error) {
+	cmd := exec.Command("docker", args...)
+	out := bytes.Buffer{}
+	cmd.Stdout = io.MultiWriter(&out, ginkgo.GinkgoWriter)
+	cmd.Stderr = ginkgo.GinkgoWriter
+	ginkgo.GinkgoWriter.Println("$", strings.Join(cmd.Args, " "))
+	err := cmd.Run()
+
+	return strings.TrimSpace(out.String()), err
+}
+
+func RunContainer(spec ContainerSpec) (string, error) {
+	containerID, err := CreateContainer(spec)
+	if err != nil {
+		return "", err
+	}
+
+	return containerID, StartContainer(containerID)
+}
+
+func StartContainer(name string) error {
+	_, err := Command("start", name)
+	return err
+}
+
+func CreateContainer(spec ContainerSpec) (string, error) {
+	args := []string{
+		"create",
+		"--pull=always",
+	}
+
+	if spec.HealthCmd != "" {
+		args = append(args, "--health-cmd="+spec.HealthCmd)
+	}
+
+	if spec.HealthInterval != "" {
+		args = append(args, "--health-interval="+spec.HealthInterval)
+	}
+
+	for _, e := range spec.Env {
+		args = append(args, "--env="+e)
+	}
+
+	for _, v := range spec.Volumes {
+		args = append(args, "--volume="+v)
+	}
+
+	for _, p := range spec.Ports {
+		args = append(args, "--publish="+p)
+	}
+
+	args = append(args, spec.Image)
+	args = append(args, spec.Args...)
+
+	return Command(args...)
+}
+
+func WaitHealthy(container string, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			return errors.New("timeout waiting for healthy container")
+		case <-ticker.C:
+			result, err := Command("container", "inspect", "--format={{.State.Status}} {{.State.Health.Status}}", container)
+			if err != nil {
+				return fmt.Errorf("error inspecting container: %v", err)
+			}
+
+			if strings.HasPrefix(result, "exited ") {
+				return fmt.Errorf("container exited")
+			}
+
+			if result == "running healthy" {
+				return nil
+			}
+		}
+	}
+}
+
+func RemoveContainer(name string) error {
+	_, err := Command("container", "rm", "--force", "--volumes", name)
+	return err
+}
+
+func ContainerPort(containerID, portSpec string) (string, error) {
+	hostPort, err := Command("container", "port", containerID, portSpec)
+	if err != nil {
+		return "", err
+	}
+
+	_, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return "", err
+	}
+
+	return port, nil
+}

--- a/src/mysql-diag/main.go
+++ b/src/mysql-diag/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	messages := ui.Report(ui.ReporterParams{
 		NeedsBootstrap:      aggregatedData.NeedsBootstrap,
+		TLSMisconfigured:    aggregatedData.TLSMisconfigured,
 		DiskSpaceIssues:     aggregatedData.DiskSpaceIssues,
 		NodeClusterStatuses: aggregatedData.NodeClusterStatuses,
 	})

--- a/src/mysql-diag/ui/reporter.go
+++ b/src/mysql-diag/ui/reporter.go
@@ -12,12 +12,26 @@ import (
 
 type ReporterParams struct {
 	NeedsBootstrap      bool
+	TLSMisconfigured    bool
 	DiskSpaceIssues     []disk.DiskSpaceIssue
 	NodeClusterStatuses []*database.NodeClusterStatus
 }
 
 func Report(params ReporterParams) []string {
 	messages := []string{}
+
+	if params.TLSMisconfigured {
+		messages = append(messages, msg.Alert(
+			"\n[CRITICAL] mysql-diag cannot connect to one or more MySQL nodes: TLS certificate "+
+				"verification failed. Verify that db_tls.ca and db_tls.server_name are correctly configured.",
+		))
+		if params.NeedsBootstrap {
+			messages = append(messages, msg.Alert(
+				"\n[WARNING] Do not bootstrap — cluster health cannot be determined while TLS is misconfigured.",
+			))
+			return messages
+		}
+	}
 
 	if params.NeedsBootstrap {
 		slices.SortStableFunc(params.NodeClusterStatuses, func(i, j *database.NodeClusterStatus) int {

--- a/src/mysql-diag/ui/reporter_test.go
+++ b/src/mysql-diag/ui/reporter_test.go
@@ -59,6 +59,38 @@ var _ = Describe("Reporter", func() {
 		})
 	})
 
+	Context("when TLS is misconfigured and all nodes are unreachable", func() {
+		BeforeEach(func() {
+			messages = ui.Report(ui.ReporterParams{
+				NeedsBootstrap:   true,
+				TLSMisconfigured: true,
+				DiskSpaceIssues:  diskSpaceIssues,
+				// Status is nil on all nodes — connection failed before any query ran
+				NodeClusterStatuses: []*database.NodeClusterStatus{
+					{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-1"}},
+					{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-2"}},
+					{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-3"}},
+				},
+			})
+		})
+
+		It("reports the TLS certificate error", func() {
+			Expect(messages).To(ContainElement(MatchRegexp(`\[CRITICAL\].*TLS certificate verification failed`)))
+		})
+
+		It("does not recommend bootstrapping", func() {
+			Expect(messages).NotTo(ContainElement(MatchRegexp(`\[CRITICAL\] You must bootstrap`)))
+		})
+
+		It("warns not to bootstrap due to the TLS error", func() {
+			Expect(messages).To(ContainElement(MatchRegexp(`\[WARNING\] Do not bootstrap`)))
+		})
+
+		It("does not suggest downloading logs", func() {
+			Expect(messages).NotTo(ContainElement(MatchRegexp(`\[CRITICAL\] Run the bosh logs command`)))
+		})
+	})
+
 	Context("when needing bootstrap", func() {
 		BeforeEach(func() {
 			needsBootstrap = true


### PR DESCRIPTION
This PR introduces support for strict TLS validation when `mysql-diag` connects to cluster nodes to report status, while enforcing encrypted connections by default. 

**Behavioral changes**
* **Full TLS Verification:** Added support for passing a CA certificate and server name to enable fully validated MySQL connections. 
* **Enforced Encryption (Default):** The default behavior now strictly enforces TLS and rejects downgrades to unencrypted connections. To mirror existing behavior and maintain backward compatibility, CA verification remains disabled by default unless the CA and server name are provided.
* **Smarter Error Messaging:** Improved the diagnostic output for TLS failures. Previously, if nodes were unreachable, `mysql-diag` would generically recommend a cluster "bootstrap." Now, if a node is unreachable specifically due to a TLS verification failure (when a CA cert is provided), it surfaces a clear, accurate error message instead.