### PR TITLE
fix(mysql-diag): open read permissions for test certs

### DIFF
--- a/src/mysql-diag/integration/mysql_diag_config_test.go
+++ b/src/mysql-diag/integration/mysql_diag_config_test.go
@@ -47,6 +47,8 @@ var _ = Describe("mysql-diag TLS config", Ordered, Label("integration"), func() 
 
 		certDir, err := os.MkdirTemp("", "mysql-tls-certs-*")
 		Expect(err).NotTo(HaveOccurred())
+		// Ensure cert dir is readable by docker
+		Expect(os.Chmod(certDir, 0o755)).To(Succeed())
 		DeferCleanup(func() { _ = os.RemoveAll(certDir) })
 
 		for name, data := range map[string][]byte{


### PR DESCRIPTION
If the tests are run a different user than the docker container, the bind-mounted tmpdir may be unreadable by the mysqld container which makes integration tests fail because TLS will be disabled (no ssl material available)

This ensures the temporary directory where test certificates are written is world readable.

[TNZGOV-14802]
ai-assisted=no