### PR TITLE
fix(mysql-diag): check valid cluster status

### DIFF
--- a/src/mysql-diag/ui/reporter.go
+++ b/src/mysql-diag/ui/reporter.go
@@ -35,7 +35,14 @@ func Report(params ReporterParams) []string {
 
 	if params.NeedsBootstrap {
 		slices.SortStableFunc(params.NodeClusterStatuses, func(i, j *database.NodeClusterStatus) int {
-			return cmp.Compare(i.Status.LastApplied, j.Status.LastApplied)
+			var iLast, jLast int
+			if i.Status != nil {
+				iLast = i.Status.LastApplied
+			}
+			if j.Status != nil {
+				jLast = j.Status.LastApplied
+			}
+			return cmp.Compare(iLast, jLast)
 		})
 		bootstrapNode := fmt.Sprintf("%s/%s", params.NodeClusterStatuses[len(params.NodeClusterStatuses)-1].Node.Name, params.NodeClusterStatuses[len(params.NodeClusterStatuses)-1].Node.UUID)
 		messages = append(messages, msg.Alert("\n[CRITICAL] You must bootstrap the cluster. Follow these instructions: https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-mysql-tanzu-platform/10-1/mysql-tp/bootstrapping.html"))
@@ -64,7 +71,7 @@ Do not perform the following unless instructed by Pivotal Support:
 		name := ""
 		minLocalIndex := maxUUID
 		for _, status := range params.NodeClusterStatuses {
-			if status.Status.LocalIndex != "" && status.Status.LocalIndex < minLocalIndex {
+			if status.Status != nil && status.Status.LocalIndex != "" && status.Status.LocalIndex < minLocalIndex {
 				minLocalIndex = status.Status.LocalIndex
 				name = fmt.Sprintf("%s/%s", status.Node.Name, status.Node.UUID)
 			}

--- a/src/mysql-diag/ui/reporter_test.go
+++ b/src/mysql-diag/ui/reporter_test.go
@@ -181,6 +181,55 @@ var _ = Describe("Reporter", func() {
 		})
 	})
 
+	Context("when needing bootstrap and some nodes have nil Status", func() {
+		It("does not panic when sorting nodes with nil Status", func() {
+			Expect(func() {
+				ui.Report(ui.ReporterParams{
+					NeedsBootstrap: true,
+					NodeClusterStatuses: []*database.NodeClusterStatus{
+						{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-1"}, Status: nil},
+						{
+							Node:   config.MysqlNode{Name: "mysql", UUID: "uuid-2"},
+							Status: &database.GaleraStatus{LastApplied: 500},
+						},
+						{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-3"}, Status: nil},
+					},
+				})
+			}).NotTo(Panic())
+		})
+	})
+
+	Context("when healthy and some nodes have nil Status", func() {
+		It("does not panic when iterating nodes with nil Status", func() {
+			Expect(func() {
+				ui.Report(ui.ReporterParams{
+					NeedsBootstrap: false,
+					NodeClusterStatuses: []*database.NodeClusterStatus{
+						{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-1"}, Status: nil},
+						{
+							Node:   config.MysqlNode{Name: "mysql", UUID: "uuid-2"},
+							Status: &database.GaleraStatus{LocalIndex: "8e9483c8-beed"},
+						},
+					},
+				})
+			}).NotTo(Panic())
+		})
+
+		It("still identifies the writable node from nodes that do have a Status", func() {
+			messages = ui.Report(ui.ReporterParams{
+				NeedsBootstrap: false,
+				NodeClusterStatuses: []*database.NodeClusterStatus{
+					{Node: config.MysqlNode{Name: "mysql", UUID: "uuid-1"}, Status: nil},
+					{
+						Node:   config.MysqlNode{Name: "mysql", UUID: "uuid-2"},
+						Status: &database.GaleraStatus{LocalIndex: "8e9483c8-beed"},
+					},
+				},
+			})
+			Expect(messages).To(ContainElement(MatchRegexp(`NOTE: Proxies will currently attempt to direct traffic to "mysql/uuid-2"`)))
+		})
+	})
+
 	Context("when everything is wrong", func() {
 		BeforeEach(func() {
 			isCanaryHealthy = false


### PR DESCRIPTION
ui.Report dereferenced NodeClusterStatus.Status without a nil check when sorting nodes for the bootstrap recommendation and when locating the writable node. Status starts nil for every node and stays nil whenever a node's galera status query fails and no galera-agent link is configured to backfill it, which caused mysql-diag to panic instead of producing a report.

Add nil guards at both sites so an unreachable/uninitialized node is treated as unknown rather than crashing the whole report.

Fixes #22